### PR TITLE
fix type mismatch

### DIFF
--- a/src/Service/Request/RequestService.php
+++ b/src/Service/Request/RequestService.php
@@ -141,7 +141,7 @@ abstract class RequestService implements RequestServiceInterface
     /**
      * Generate an error code table of command
      *
-     * @param string $errorCode - Error code
+     * @param int $errorCode - Error code
      *
      * @throws Exception
      */

--- a/src/Service/Request/RequestServiceInterface.php
+++ b/src/Service/Request/RequestServiceInterface.php
@@ -63,7 +63,7 @@ interface RequestServiceInterface
     *
     * @param int $errorCode Code of error (See CommandResponseError Util).
     * @throws Exception If the processing fails unexpectedly.
-    * @return string
+    * @return void
     */
     public function processCommandServResponceError(int $errorCode);
 


### PR DESCRIPTION
In class that overrides RequestService phpstan rises some errors 
` ------ ---------------------------------------------------------------------------------------------------------- 
  Line   src/Integration/OnlyOffice/Service/RequestService.php                                                     
 ------ ---------------------------------------------------------------------------------------------------------- 
  42     Parameter #1 $errorCode (string) of method                                                                
         Integration\OnlyOffice\Service\RequestService::processCommandServResponceError()                          
         should be compatible with parameter $errorCode (int) of method                                            
         Onlyoffice\DocsIntegrationSdk\Service\Request\RequestServiceInterface::processCommandServResponceError()  
         🪪 method.childParameterType                                                                              
  42     Return type (void) of method                                                                              
         Integration\OnlyOffice\Service\RequestService::processCommandServResponceError()                          
         should be compatible with return type (string) of method                                                  
         Onlyoffice\DocsIntegrationSdk\Service\Request\RequestService::processCommandServResponceError()           
         🪪 method.childReturnType                                                                                 
  42     Return type (void) of method                                                                              
         Integration\OnlyOffice\Service\RequestService::processCommandServResponceError()                          
         should be compatible with return type (string) of method                                                  
         Onlyoffice\DocsIntegrationSdk\Service\Request\RequestServiceInterface::processCommandServResponceError()  
         🪪 method.childReturnType               `

Please consider changes, if it correct
Thx